### PR TITLE
Avoid a crash on Linux

### DIFF
--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -709,6 +709,7 @@ bool Graph::getEffectiveNodeOrOptimalFunnel(uint32_t &effectiveNode, uint32_t &n
             }
         }
     }
+    return true;
 }
 
 bool Graph::getGoodFunnel(uint32_t &node1, uint32_t &node2) const {

--- a/src/Graph.hpp
+++ b/src/Graph.hpp
@@ -167,6 +167,7 @@ public:
                 removedNeighbors.insert(removedNeighbors.end(), (*edgeBuffer)[offset]);
             }
         }
+        return true;
     }
 
     template <typename Container, typename OriginalNodesContainer>

--- a/src/Reductions.cpp
+++ b/src/Reductions.cpp
@@ -148,6 +148,7 @@ bool Reductions::removeDominatedNodes2(const uint32_t &theta) {
             }
         }
     }
+    return true;
 }
 
 bool Reductions::removeDesks() {


### PR DESCRIPTION
When we run this program on Linux, it aborts with the following error:

```
$ ./mis datasets/100/graph_100_1000.txt
58
terminate called after throwing an instance of 'std::out_of_range'
  what():  vector::_M_range_check: __n (which is 15) >= this->size() (which is 12)
Aborted (core dumped)
```

This pull request resolves this issue by adding missing return statements.